### PR TITLE
Load hyperref before any `\newtcolorbox`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased](https://github.com/gusbrs/zref-clever/compare/v0.3.4...HEAD)
 
+### Fixed
+- In tcolorbox how-to, `hyperref` should be loaded before any `\newtcolorbox`es.
+
 ## [v0.3.4](https://github.com/gusbrs/zref-clever/compare/v0.3.3...v0.3.4) (2023-02-13)
 
 ### Added

--- a/testfiles/zc-howto-tcolorbox01.lvt
+++ b/testfiles/zc-howto-tcolorbox01.lvt
@@ -24,6 +24,8 @@
 \tcbuselibrary{theorems}
 \tcbset{label is zlabel}
 
+\usepackage{hyperref}
+
 \newtcolorbox[auto counter,number within=section]{pabox}[2][]{%
   label type=example,
   title=Example~\thetcbcounter: #2,#1}
@@ -38,8 +40,6 @@
   Name-pl=Mytheorems,
   name-pl=mytheorems,
 }
-
-\usepackage{hyperref}
 
 \ExplSyntaxOn
 \bool_set_true:N \l__zrefclever_verbose_testing_bool

--- a/testfiles/zc-howto-tcolorbox01.tlg
+++ b/testfiles/zc-howto-tcolorbox01.tlg
@@ -4,20 +4,20 @@ Don't change this file in any respect.
 TEST 1: Reference: Box 1
 ============================================================
 > \l__zrefclever_typeset_queue_curr_tl=\__zrefclever_hyperlink:nnn
-{}{tcb@cnt@pabox.1}{\group_begin: example\group_end: \nobreakspace
+{}{tcb@cnt@pabox.1.1}{\group_begin: example\group_end: \nobreakspace
 \group_begin: 1.1\group_end: }.
 <recently read> }
 l. ...\setbox0=\hbox{\testtmp
                             }
 > \l__zrefclever_typeset_queue_curr_tl=\__zrefclever_hyperlink:nnn
-{}{tcb@cnt@pabox.1}{\group_begin: page\group_end: \nobreakspace \group_begin:
-1\group_end: }.
+{}{tcb@cnt@pabox.1.1}{\group_begin: page\group_end: \nobreakspace
+\group_begin: 1\group_end: }.
 <recently read> }
 l. ...\setbox0=\hbox{\testtmp
                             }
 > \box...=
 \hbox(6.94444+1.94444)x97.5002
-.\pdfstartlink(*+*)x* attr{/Border[0 0 1]/H/I/C[1 0 0]} action goto name{tcb@cnt@pabox.1}
+.\pdfstartlink(*+*)x* attr{/Border[0 0 1]/H/I/C[1 0 0]} action goto name{tcb@cnt@pabox.1.1}
 .\OT1/cmr/m/n/10 e
 .\OT1/cmr/m/n/10 x
 .\OT1/cmr/m/n/10 a
@@ -35,7 +35,7 @@ l. ...\setbox0=\hbox{\testtmp
 .\OT1/cmr/m/n/10 o
 .\OT1/cmr/m/n/10 n
 .\glue 3.33333 plus 1.66666 minus 1.11111
-.\pdfstartlink(*+*)x* attr{/Border[0 0 1]/H/I/C[1 0 0]} action goto name{tcb@cnt@pabox.1}
+.\pdfstartlink(*+*)x* attr{/Border[0 0 1]/H/I/C[1 0 0]} action goto name{tcb@cnt@pabox.1.1}
 .\OT1/cmr/m/n/10 p
 .\OT1/cmr/m/n/10 a
 .\OT1/cmr/m/n/10 g
@@ -51,20 +51,20 @@ l. ...\showbox0
 TEST 2: Reference: Box 2
 ============================================================
 > \l__zrefclever_typeset_queue_curr_tl=\__zrefclever_hyperlink:nnn
-{}{tcb@cnt@pabox.2}{\group_begin: solution\group_end: \nobreakspace
+{}{tcb@cnt@pabox.1.2}{\group_begin: solution\group_end: \nobreakspace
 \group_begin: 1.2\group_end: }.
 <recently read> }
 l. ...\setbox0=\hbox{\testtmp
                             }
 > \l__zrefclever_typeset_queue_curr_tl=\__zrefclever_hyperlink:nnn
-{}{tcb@cnt@pabox.2}{\group_begin: page\group_end: \nobreakspace \group_begin:
-1\group_end: }.
+{}{tcb@cnt@pabox.1.2}{\group_begin: page\group_end: \nobreakspace
+\group_begin: 1\group_end: }.
 <recently read> }
 l. ...\setbox0=\hbox{\testtmp
                             }
 > \box...=
 \hbox(6.94444+1.94444)x96.16687
-.\pdfstartlink(*+*)x* attr{/Border[0 0 1]/H/I/C[1 0 0]} action goto name{tcb@cnt@pabox.2}
+.\pdfstartlink(*+*)x* attr{/Border[0 0 1]/H/I/C[1 0 0]} action goto name{tcb@cnt@pabox.1.2}
 .\OT1/cmr/m/n/10 s
 .\OT1/cmr/m/n/10 o
 .\OT1/cmr/m/n/10 l
@@ -83,7 +83,7 @@ l. ...\setbox0=\hbox{\testtmp
 .\OT1/cmr/m/n/10 o
 .\OT1/cmr/m/n/10 n
 .\glue 3.33333 plus 1.66666 minus 1.11111
-.\pdfstartlink(*+*)x* attr{/Border[0 0 1]/H/I/C[1 0 0]} action goto name{tcb@cnt@pabox.2}
+.\pdfstartlink(*+*)x* attr{/Border[0 0 1]/H/I/C[1 0 0]} action goto name{tcb@cnt@pabox.1.2}
 .\OT1/cmr/m/n/10 p
 .\OT1/cmr/m/n/10 a
 .\OT1/cmr/m/n/10 g
@@ -99,20 +99,20 @@ l. ...\showbox0
 TEST 3: Reference: My theorem
 ============================================================
 > \l__zrefclever_typeset_queue_curr_tl=\__zrefclever_hyperlink:nnn
-{}{tcb@cnt@mytheo.1}{\group_begin: mytheorem\group_end: \nobreakspace
+{}{tcb@cnt@mytheo.1.1}{\group_begin: mytheorem\group_end: \nobreakspace
 \group_begin: 1.1\group_end: }.
 <recently read> }
 l. ...\setbox0=\hbox{\testtmp
                             }
 > \l__zrefclever_typeset_queue_curr_tl=\__zrefclever_hyperlink:nnn
-{}{tcb@cnt@mytheo.1}{\group_begin: page\group_end: \nobreakspace \group_begin:
-1\group_end: }.
+{}{tcb@cnt@mytheo.1.1}{\group_begin: page\group_end: \nobreakspace
+\group_begin: 1\group_end: }.
 <recently read> }
 l. ...\setbox0=\hbox{\testtmp
                             }
 > \box...=
 \hbox(6.94444+1.94444)x110.58356
-.\pdfstartlink(*+*)x* attr{/Border[0 0 1]/H/I/C[1 0 0]} action goto name{tcb@cnt@mytheo.1}
+.\pdfstartlink(*+*)x* attr{/Border[0 0 1]/H/I/C[1 0 0]} action goto name{tcb@cnt@mytheo.1.1}
 .\OT1/cmr/m/n/10 m
 .\kern-0.27779
 .\OT1/cmr/m/n/10 y
@@ -133,7 +133,7 @@ l. ...\setbox0=\hbox{\testtmp
 .\OT1/cmr/m/n/10 o
 .\OT1/cmr/m/n/10 n
 .\glue 3.33333 plus 1.66666 minus 1.11111
-.\pdfstartlink(*+*)x* attr{/Border[0 0 1]/H/I/C[1 0 0]} action goto name{tcb@cnt@mytheo.1}
+.\pdfstartlink(*+*)x* attr{/Border[0 0 1]/H/I/C[1 0 0]} action goto name{tcb@cnt@mytheo.1.1}
 .\OT1/cmr/m/n/10 p
 .\OT1/cmr/m/n/10 a
 .\OT1/cmr/m/n/10 g
@@ -145,13 +145,13 @@ l. ...\setbox0=\hbox{\testtmp
 ! OK.
 l. ...\showbox0
 > \l__zrefclever_typeset_queue_curr_tl=\__zrefclever_hyperlink:nnn
-{}{tcb@cnt@mytheo.1}{\group_begin: This is my title\group_end: }.
+{}{tcb@cnt@mytheo.1.1}{\group_begin: This is my title\group_end: }.
 <recently read> }
 l. ...\setbox0=\hbox{\testtmp
                             }
 > \box...=
 \hbox(6.94444+1.94444)x67.33344
-.\pdfstartlink(*+*)x* attr{/Border[0 0 1]/H/I/C[1 0 0]} action goto name{tcb@cnt@mytheo.1}
+.\pdfstartlink(*+*)x* attr{/Border[0 0 1]/H/I/C[1 0 0]} action goto name{tcb@cnt@mytheo.1.1}
 .\OT1/cmr/m/n/10 T
 .\OT1/cmr/m/n/10 h
 .\OT1/cmr/m/n/10 i

--- a/testfiles/zc-howto-tcolorbox01.xetex.tlg
+++ b/testfiles/zc-howto-tcolorbox01.xetex.tlg
@@ -4,20 +4,20 @@ Don't change this file in any respect.
 TEST 1: Reference: Box 1
 ============================================================
 > \l__zrefclever_typeset_queue_curr_tl=\__zrefclever_hyperlink:nnn
-{}{tcb@cnt@pabox.1}{\group_begin: example\group_end: \nobreakspace
+{}{tcb@cnt@pabox.1.1}{\group_begin: example\group_end: \nobreakspace
 \group_begin: 1.1\group_end: }.
 <recently read> }
 l. ...\setbox0=\hbox{\testtmp
                             }
 > \l__zrefclever_typeset_queue_curr_tl=\__zrefclever_hyperlink:nnn
-{}{tcb@cnt@pabox.1}{\group_begin: page\group_end: \nobreakspace \group_begin:
-1\group_end: }.
+{}{tcb@cnt@pabox.1.1}{\group_begin: page\group_end: \nobreakspace
+\group_begin: 1\group_end: }.
 <recently read> }
 l. ...\setbox0=\hbox{\testtmp
                             }
 > \box...=
 \hbox(6.94444+1.94444)x97.5002
-.\special{pdf:bann<</Type/Annot/Subtype/Link/Border[0 0 1]/H/I/C[1 0 0]/A<</S/GoTo/D(tcb@cnt@pabox.1)>>>>}
+.\special{pdf:bann<</Type/Annot/Subtype/Link/Border[0 0 1]/H/I/C[1 0 0]/A<</S/GoTo/D(tcb@cnt@pabox.1.1)>>>>}
 .\OT1/cmr/m/n/10 e
 .\OT1/cmr/m/n/10 x
 .\OT1/cmr/m/n/10 a
@@ -35,7 +35,7 @@ l. ...\setbox0=\hbox{\testtmp
 .\OT1/cmr/m/n/10 o
 .\OT1/cmr/m/n/10 n
 .\glue 3.33333 plus 1.66666 minus 1.11111
-.\special{pdf:bann<</Type/Annot/Subtype/Link/Border[0 0 1]/H/I/C[1 0 0]/A<</S/GoTo/D(tcb@cnt@pabox.1)>>>>}
+.\special{pdf:bann<</Type/Annot/Subtype/Link/Border[0 0 1]/H/I/C[1 0 0]/A<</S/GoTo/D(tcb@cnt@pabox.1.1)>>>>}
 .\OT1/cmr/m/n/10 p
 .\OT1/cmr/m/n/10 a
 .\OT1/cmr/m/n/10 g
@@ -51,20 +51,20 @@ l. ...\showbox0
 TEST 2: Reference: Box 2
 ============================================================
 > \l__zrefclever_typeset_queue_curr_tl=\__zrefclever_hyperlink:nnn
-{}{tcb@cnt@pabox.2}{\group_begin: solution\group_end: \nobreakspace
+{}{tcb@cnt@pabox.1.2}{\group_begin: solution\group_end: \nobreakspace
 \group_begin: 1.2\group_end: }.
 <recently read> }
 l. ...\setbox0=\hbox{\testtmp
                             }
 > \l__zrefclever_typeset_queue_curr_tl=\__zrefclever_hyperlink:nnn
-{}{tcb@cnt@pabox.2}{\group_begin: page\group_end: \nobreakspace \group_begin:
-1\group_end: }.
+{}{tcb@cnt@pabox.1.2}{\group_begin: page\group_end: \nobreakspace
+\group_begin: 1\group_end: }.
 <recently read> }
 l. ...\setbox0=\hbox{\testtmp
                             }
 > \box...=
 \hbox(6.94444+1.94444)x96.16687
-.\special{pdf:bann<</Type/Annot/Subtype/Link/Border[0 0 1]/H/I/C[1 0 0]/A<</S/GoTo/D(tcb@cnt@pabox.2)>>>>}
+.\special{pdf:bann<</Type/Annot/Subtype/Link/Border[0 0 1]/H/I/C[1 0 0]/A<</S/GoTo/D(tcb@cnt@pabox.1.2)>>>>}
 .\OT1/cmr/m/n/10 s
 .\OT1/cmr/m/n/10 o
 .\OT1/cmr/m/n/10 l
@@ -83,7 +83,7 @@ l. ...\setbox0=\hbox{\testtmp
 .\OT1/cmr/m/n/10 o
 .\OT1/cmr/m/n/10 n
 .\glue 3.33333 plus 1.66666 minus 1.11111
-.\special{pdf:bann<</Type/Annot/Subtype/Link/Border[0 0 1]/H/I/C[1 0 0]/A<</S/GoTo/D(tcb@cnt@pabox.2)>>>>}
+.\special{pdf:bann<</Type/Annot/Subtype/Link/Border[0 0 1]/H/I/C[1 0 0]/A<</S/GoTo/D(tcb@cnt@pabox.1.2)>>>>}
 .\OT1/cmr/m/n/10 p
 .\OT1/cmr/m/n/10 a
 .\OT1/cmr/m/n/10 g
@@ -99,20 +99,20 @@ l. ...\showbox0
 TEST 3: Reference: My theorem
 ============================================================
 > \l__zrefclever_typeset_queue_curr_tl=\__zrefclever_hyperlink:nnn
-{}{tcb@cnt@mytheo.1}{\group_begin: mytheorem\group_end: \nobreakspace
+{}{tcb@cnt@mytheo.1.1}{\group_begin: mytheorem\group_end: \nobreakspace
 \group_begin: 1.1\group_end: }.
 <recently read> }
 l. ...\setbox0=\hbox{\testtmp
                             }
 > \l__zrefclever_typeset_queue_curr_tl=\__zrefclever_hyperlink:nnn
-{}{tcb@cnt@mytheo.1}{\group_begin: page\group_end: \nobreakspace \group_begin:
-1\group_end: }.
+{}{tcb@cnt@mytheo.1.1}{\group_begin: page\group_end: \nobreakspace
+\group_begin: 1\group_end: }.
 <recently read> }
 l. ...\setbox0=\hbox{\testtmp
                             }
 > \box...=
 \hbox(6.94444+1.94444)x110.58356
-.\special{pdf:bann<</Type/Annot/Subtype/Link/Border[0 0 1]/H/I/C[1 0 0]/A<</S/GoTo/D(tcb@cnt@mytheo.1)>>>>}
+.\special{pdf:bann<</Type/Annot/Subtype/Link/Border[0 0 1]/H/I/C[1 0 0]/A<</S/GoTo/D(tcb@cnt@mytheo.1.1)>>>>}
 .\OT1/cmr/m/n/10 m
 .\kern-0.27779
 .\OT1/cmr/m/n/10 y
@@ -133,7 +133,7 @@ l. ...\setbox0=\hbox{\testtmp
 .\OT1/cmr/m/n/10 o
 .\OT1/cmr/m/n/10 n
 .\glue 3.33333 plus 1.66666 minus 1.11111
-.\special{pdf:bann<</Type/Annot/Subtype/Link/Border[0 0 1]/H/I/C[1 0 0]/A<</S/GoTo/D(tcb@cnt@mytheo.1)>>>>}
+.\special{pdf:bann<</Type/Annot/Subtype/Link/Border[0 0 1]/H/I/C[1 0 0]/A<</S/GoTo/D(tcb@cnt@mytheo.1.1)>>>>}
 .\OT1/cmr/m/n/10 p
 .\OT1/cmr/m/n/10 a
 .\OT1/cmr/m/n/10 g
@@ -145,13 +145,13 @@ l. ...\setbox0=\hbox{\testtmp
 ! OK.
 l. ...\showbox0
 > \l__zrefclever_typeset_queue_curr_tl=\__zrefclever_hyperlink:nnn
-{}{tcb@cnt@mytheo.1}{\group_begin: This is my title\group_end: }.
+{}{tcb@cnt@mytheo.1.1}{\group_begin: This is my title\group_end: }.
 <recently read> }
 l. ...\setbox0=\hbox{\testtmp
                             }
 > \box...=
 \hbox(6.94444+1.94444)x67.33344
-.\special{pdf:bann<</Type/Annot/Subtype/Link/Border[0 0 1]/H/I/C[1 0 0]/A<</S/GoTo/D(tcb@cnt@mytheo.1)>>>>}
+.\special{pdf:bann<</Type/Annot/Subtype/Link/Border[0 0 1]/H/I/C[1 0 0]/A<</S/GoTo/D(tcb@cnt@mytheo.1.1)>>>>}
 .\OT1/cmr/m/n/10 T
 .\OT1/cmr/m/n/10 h
 .\OT1/cmr/m/n/10 i

--- a/zref-clever.tex
+++ b/zref-clever.tex
@@ -2073,6 +2073,7 @@ with the \opt{label type} option.
 \usepackage{tcolorbox}
 \tcbuselibrary{theorems}
 \tcbset{label is zlabel}
+\usepackage{hyperref}
 \newtcolorbox[auto counter,number within=section]{pabox}[2][]{%
   label type=example,
   title=Example~\thetcbcounter: #2,#1}
@@ -2087,7 +2088,6 @@ with the \opt{label type} option.
   Name-pl=Mytheorems,
   name-pl=mytheorems,
 }
-\usepackage{hyperref}
 \begin{document}
 \section{Section 1}
 \zlabel{sec:section-1}


### PR DESCRIPTION
From the testfile one can see the previous hyperref target names like `tcb@cnt@pabox.1` are not unique throughout the document, for example the first `pabox` in section 1 and section 2 will use the same target name.

Loading `hyperref` before any `\newtcolorbox` and friends fixes this problem. Now the hyperref target are named like `tcb@cnt@pabox.1.1` (`<box name>.<sec num>.<box num>`), which reflect the setting `number within=section`.

See a related issue in https://github.com/T-F-S/tcolorbox/issues/135.

PS: Since `\tcbuselibrary` may load packages as well, just in case, loading of `hyperref` is moved after `\tcbuselibrary`.