### PR TITLE
Update GitHub Actions and drop unneeded steps

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -109,19 +109,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
-      - name: Generate unique ID
-        id: get-id
-        run: |
-          echo -n ::set-output name=id::
-          cat /proc/sys/kernel/random/uuid
-      - name: Load cache
-        uses: actions/cache@v3
-        with:
-          path: ~/texlive
-          key: texlive-v0-${{ steps.get-id.outputs.id }}
-          restore-keys: texlive-v0-
       - name: Install TeX Live
-        uses: zauguin/install-texlive@v1
+        uses: zauguin/install-texlive@v2
         with:
           packages: ${{ env.ZC_PACKAGE_LIST }}
       - name: Run tests
@@ -133,19 +122,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
-      - name: Generate unique ID
-        id: get-id
-        run: |
-          echo -n ::set-output name=id::
-          cat /proc/sys/kernel/random/uuid
-      - name: Load cache
-        uses: actions/cache@v3
-        with:
-          path: ~/texlive
-          key: texlive-v0-${{ steps.get-id.outputs.id }}
-          restore-keys: texlive-v0-
       - name: Install TeX Live
-        uses: zauguin/install-texlive@v1
+        uses: zauguin/install-texlive@v2
         with:
           packages: ${{ env.ZC_PACKAGE_LIST }}
       - name: Compile documentation

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -108,14 +108,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Generate unique ID
         id: get-id
         run: |
           echo -n ::set-output name=id::
           cat /proc/sys/kernel/random/uuid
       - name: Load cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/texlive
           key: texlive-v0-${{ steps.get-id.outputs.id }}
@@ -132,14 +132,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Generate unique ID
         id: get-id
         run: |
           echo -n ::set-output name=id::
           cat /proc/sys/kernel/random/uuid
       - name: Load cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/texlive
           key: texlive-v0-${{ steps.get-id.outputs.id }}


### PR DESCRIPTION
To clear warnings thrown by a workflow run.
- current warnings https://github.com/gusbrs/zref-clever/actions/runs/4211065886
- effect (no warnings) of current PR https://github.com/muzimuzhi/zref-clever/actions/runs/4211127162

![image](https://user-images.githubusercontent.com/6376638/219865698-51559e73-efa1-4bbd-b5d8-858266103464.png)

See commit messages for more info.

------

BTW, you may be interested in
- adding a dependabot to be noticed with new major releases of dependent actions
  - doc https://docs.github.com/en/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot
  - usage in pgf https://github.com/pgf-tikz/pgf/blob/master/.github/dependabot.yml and texstudio https://github.com/texstudio-org/texstudio/blob/master/.github/dependabot.yml
- using an updated-weekly texlive docker image
  - https://gitlab.com/islandoftex/images/texlive
  - usage in pgf https://github.com/pgf-tikz/pgf/blob/dceb378b263061856b9a21082e5dc6fffdcdf494/.github/workflows/check.yml#L9