### PR TITLE
Test against full expansion of \babelname and \mainbabelname

### DIFF
--- a/testfiles/zc-opt-lang05.luatex.tlg
+++ b/testfiles/zc-opt-lang05.luatex.tlg
@@ -9,10 +9,10 @@ l. ...\testtmp
 > \l__zrefclever_ref_language_tl=\l__zrefclever_current_language_tl .
 <recently read> }
 l. ...\testtmp
-> \babelname=\__cmd_start_optimized: \babelname code .
+> \babelname=>ngerman.
 <recently read> }
 l. ...\testtmp
-> \mainbabelname=\__cmd_start_optimized: \mainbabelname code .
+> \mainbabelname=>ngerman.
 <recently read> }
 l. ...\testtmp
 > \box...=

--- a/testfiles/zc-opt-lang05.lvt
+++ b/testfiles/zc-opt-lang05.lvt
@@ -29,9 +29,11 @@
 \testtmp
 \renewcommand{\testtmp}{ \tl_show:N \l__zrefclever_ref_language_tl }
 \testtmp
-\renewcommand{\testtmp}{ \tl_show:N \babelname }
+\renewcommand{\testtmp}
+  { \tl_show:e { \token_to_str:N \babelname => \babelname } }
 \testtmp
-\renewcommand{\testtmp}{ \tl_show:N \mainbabelname }
+\renewcommand{\testtmp}
+  { \tl_show:e { \token_to_str:N \mainbabelname => \mainbabelname } }
 \testtmp
 \ExplSyntaxOff
 

--- a/testfiles/zc-opt-lang05.xetex.tlg
+++ b/testfiles/zc-opt-lang05.xetex.tlg
@@ -9,10 +9,10 @@ l. ...\testtmp
 > \l__zrefclever_ref_language_tl=\l__zrefclever_current_language_tl .
 <recently read> }
 l. ...\testtmp
-> \babelname=\__cmd_start_optimized: \babelname code .
+> \babelname=>ngerman.
 <recently read> }
 l. ...\testtmp
-> \mainbabelname=\__cmd_start_optimized: \mainbabelname code .
+> \mainbabelname=>ngerman.
 <recently read> }
 l. ...\testtmp
 > \box...=

--- a/testfiles/zc-opt-lang06.luatex.tlg
+++ b/testfiles/zc-opt-lang06.luatex.tlg
@@ -9,10 +9,10 @@ l. ...\testtmp
 > \l__zrefclever_ref_language_tl=\l__zrefclever_main_language_tl .
 <recently read> }
 l. ...\testtmp
-> \babelname=\__cmd_start_optimized: \babelname code .
+> \babelname=>ngerman.
 <recently read> }
 l. ...\testtmp
-> \mainbabelname=\__cmd_start_optimized: \mainbabelname code .
+> \mainbabelname=>ngerman.
 <recently read> }
 l. ...\testtmp
 > \box...=

--- a/testfiles/zc-opt-lang06.lvt
+++ b/testfiles/zc-opt-lang06.lvt
@@ -29,9 +29,11 @@
 \testtmp
 \renewcommand{\testtmp}{ \tl_show:N \l__zrefclever_ref_language_tl }
 \testtmp
-\renewcommand{\testtmp}{ \tl_show:N \babelname }
+\renewcommand{\testtmp}
+  { \tl_show:e { \token_to_str:N \babelname => \babelname } }
 \testtmp
-\renewcommand{\testtmp}{ \tl_show:N \mainbabelname }
+\renewcommand{\testtmp}
+  { \tl_show:e { \token_to_str:N \mainbabelname => \mainbabelname } }
 \testtmp
 \ExplSyntaxOff
 

--- a/testfiles/zc-opt-lang06.xetex.tlg
+++ b/testfiles/zc-opt-lang06.xetex.tlg
@@ -9,10 +9,10 @@ l. ...\testtmp
 > \l__zrefclever_ref_language_tl=\l__zrefclever_main_language_tl .
 <recently read> }
 l. ...\testtmp
-> \babelname=\__cmd_start_optimized: \babelname code .
+> \babelname=>ngerman.
 <recently read> }
 l. ...\testtmp
-> \mainbabelname=\__cmd_start_optimized: \mainbabelname code .
+> \mainbabelname=>ngerman.
 <recently read> }
 l. ...\testtmp
 > \box...=


### PR DESCRIPTION
After a recent `polyglossia` change (see https://github.com/reutenauer/polyglossia/commit/11c1fe955687d2fbaa8d5368e643d562296b8b76), both `\babelname` and `\mainbabelname` no longer store the name of language directly, but rather indirectly, via retrieving the value from a latex3 property variable.

```tex
% new implementation in polyglossia
\DeclareExpandableDocumentCommand \babelname { }
  {
    \prop_item:Ne  \l_xpg_langsetup_prop { \languagename / babelname }
  }

\DeclareExpandableDocumentCommand \mainbabelname { }
  {
    \prop_item:Ne  \l_xpg_langsetup_prop { \mainlanguagename / babelname }
  }
```

This `polyglossia` change made the simple `\tl_show:N \babelname` gives nothing useful, see https://github.com/gusbrs/zref-clever/commit/fa849522e764416a7c431119c4f794161bdb6c26.

This PR changes the way `\babelname` and `\mainbabelname` are shown. The new way works as far as they are defined as expandable commands. `=>` is used to distinguish from direct `\tl_show:N`, which uses `=`.
 
