### PR TITLE
Implements #58

### DIFF
--- a/zref-clever-doc.tex
+++ b/zref-clever-doc.tex
@@ -412,7 +412,8 @@ using \cs{zcsetup} (see \zcref{sec:user-interface}).
 \subsection{Dependencies}
 
 \pkg{zref-clever} requires \pkg{zref}, particularly its \pkg{zref-base},
-\pkg{zref-user} and \pkg{zref-abspage} modules, and the \LaTeX{} kernel
+\pkg{zref-user} and \pkg{zref-abspage}\footnote{Optionnaly disabled by the 
+\opt{abspage=false} option} modules, and the \LaTeX{} kernel
 \zcrequiredkernel{}, or newer.  It requires UTF-8 input encoding, which has
 been the kernel's default for some time.  It also needs \pkg{ifdraft}.  Some
 packages are leveraged by \pkg{zref-clever} if they are present, but are not
@@ -505,6 +506,25 @@ necessarily true for all cases, some restrictions may apply, as described in
 each option's documentation.
 
 \bigskip{}
+
+\DescribeOption{abspage} %
+\DescribeOption{noabspage} %
+The \opt{abspage} option controls whether the \pkg{zref-abspage} package is
+loaded, which provides the \texttt{abspage} property used for precise page
+sorting and referencing. When set to \texttt{true} (the default), the
+package loads \pkg{zref-abspage} and enables full page reference functionality
+including accurate sorting by page numbers. When set to \texttt{false}, the
+package does not load \pkg{zref-abspage}.
+
+The \opt{noabspage} option is a convenience alias for \texttt{abspage=false}.
+
+This option can only be set in the preamble using \cs{zcsetup}. Attempting to
+set it after \cs{begin}\{document\} will result in a warning.
+
+\emph{Note that when \texttt{abspage=false}, page references will still work
+for basic functionality, but sorting multiple references by page number may
+not be accurate since the package cannot access absolute page numbers without
+the \pkg{zref-abspage} module.}
 
 \DescribeOption{ref} %
 \DescribeOption{page} %

--- a/zref-clever.dtx
+++ b/zref-clever.dtx
@@ -187,7 +187,11 @@
 %    \begin{macrocode}
 \RequirePackage { zref-base }
 \RequirePackage { zref-user }
-\RequirePackage { zref-abspage }
+\bool_new:N \l_@@_abspage_bool
+\bool_set_true:N \l_@@_abspage_bool
+%    \end{macrocode}
+%
+% \begin{macrocode}
 \RequirePackage { ifdraft }
 %    \end{macrocode}
 %
@@ -3414,7 +3418,48 @@
   }
 %    \end{macrocode}
 %
+% \subsubsection*{\opt{abspage} option}
 %
+% The \texttt{abspage} option controls whether the \texttt{zref-abspage} package
+% is loaded, which provides the \texttt{abspage} property used for precise page
+% sorting and referencing. When set to \texttt{true} (the default), the package
+% loads \texttt{zref-abspage} and enables full page reference functionality including
+% accurate sorting by page numbers. When set to \texttt{false}, the package does not
+% load \texttt{zref-abspage}, which saves memory but limits page sorting capabilities.
+%
+% This option can only be set in the preamble using \texttt{\\zcsetup\{abspage=...\}}.
+% Attempting to set it after \texttt{\\begin\{document\}} will result in a warning.
+%
+% Note: When \texttt{abspage=false}, page references will still work for basic functionality,
+% but sorting multiple references by page number may not be accurate since the package
+% cannot access absolute page numbers without the \texttt{zref-abspage} module.
+%
+%    \begin{macrocode}
+\keys_define:nn { zref-clever/reference }
+  {
+    abspage .bool_set:N = \l_@@_abspage_bool ,
+    abspage .initial:n = true ,
+    abspage .default:n = true ,
+    noabspage .meta:n = { abspage = false } ,
+    noabspage .value_forbidden:n = true ,
+  }
+\AddToHook { begindocument }
+  {
+    \keys_define:nn { zref-clever/reference }
+      {
+        abspage .code:n =
+          { \msg_warning:nn { zref-clever } { option-preamble-only } { abspage } } ,
+      }
+  }
+%    \end{macrocode}
+%
+% \begin{macrocode}
+\AtBeginDocument
+  {
+    \bool_if:NT \l_@@_abspage_bool
+      { \@ifpackageloaded{zref-abspage}{}{\RequirePackage { zref-abspage } } }
+  }
+%    \end{macrocode}
 %
 % \subsubsection*{\opt{nameinlink} option}
 %


### PR DESCRIPTION
This PR implements the proposed option in the #58.

It creates a `abspage` option for the `\zcsetup` command that can only be set in the preamble and that allows to not load the `zref-abspage`. To do that, I moved the `\RequirePackage{zref-abspage}` inside a `\AtBeginDocument` command so that it is only loaded after the `\zcsetup` commands in the preamble are read if they exist, and only if the associated boolean value is true.

I'm not sure that putting it there is a very bright idea : this PR happily compiles my documents but I'm not sure how to test it on your test files. I'm also not sure what would be the exact behavior of the sorting facilities here with `abspage=false` functions.